### PR TITLE
feature: update log4j-core and log4j-api versions to 2.17.0

### DIFF
--- a/sandbox-maven/pom.xml
+++ b/sandbox-maven/pom.xml
@@ -28,13 +28,13 @@
 <dependency>
   <groupId>org.apache.logging.log4j</groupId>
   <artifactId>log4j-core</artifactId>
-  <version>2.16.0</version>
+  <version>2.17.0</version>
 </dependency>
 
 <dependency>
   <groupId>org.apache.logging.log4j</groupId>
   <artifactId>log4j-api</artifactId>
-  <version>2.16.0</version>
+  <version>2.17.0</version>
 </dependency>
 
 <!-- Updated log4j-core version to 2.16.0 for security improvements -->


### PR DESCRIPTION
Dependency updates for security improvements:

* [`sandbox-maven/pom.xml`](diffhunk://#diff-75d8df809720c2536ad2e76686704281a37be215b20842a99789e8963dba1f24L31-R37): Updated `log4j-core` and `log4j-api` dependencies from version 2.16.0 to 2.17.0.