### PR TITLE
Add ignore rule for kafka-clients CE versions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     directory: "/sandbox-maven" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.apache.kafka:kafka-clients"
+        versions: ["*-ce"]
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:


### PR DESCRIPTION
This PR adds an ignore configuration to Dependabot for `org.apache.kafka:kafka-clients` dependency to exclude all versions matching the `*-ce` pattern.

## Changes
- Added `ignore` block to the Maven package ecosystem configuration in `.github/dependabot.yml`
- Configured to ignore all `-ce` (Community Edition) versions of kafka-clients